### PR TITLE
fix: add linker flag for code signing on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "LINUX")
 	target_compile_options(plugin_example PRIVATE "-fPIC")
 endif()
 
+# install_name_tool breaks the code signature on macOS
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+	set(CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS "-o linker-signed")
+endif()
+
 # Add vendored API dependency if enabled
 option(BN_VENDOR_API "Use the Binary Ninja API submodule" ON)
 if(BN_VENDOR_API)


### PR DESCRIPTION
When using the cmake project generator for Xcode, the install target creates an unsigned binary despite the build process producing a valid ad-hoc signed binary. The reason for this as discussed here: [21854](https://gitlab.kitware.com/cmake/cmake/-/issues/21854). The summary is that because of the flags Xcode provides to the linker the `install_name_tool` binary doesn't see the `linker-signed` flag in the code signature, and thus `install_name_tool` doesn't reapply the ad-hoc signature when it deletes an rpath of the plugin dylib as part of the `bn_install_plugin` cmake  target.